### PR TITLE
Use existing fields directly for links serializer

### DIFF
--- a/drf_hal_json/pagination.py
+++ b/drf_hal_json/pagination.py
@@ -1,16 +1,13 @@
 from collections import OrderedDict
 
-from rest_framework.pagination import PageNumberPagination
+from rest_framework.pagination import CursorPagination, PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
-from drf_hal_json import LINKS_FIELD_NAME, EMBEDDED_FIELD_NAME
+from drf_hal_json import EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME
 
 
 class HalPageNumberPagination(PageNumberPagination):
-    page_size_query_param = "page_size"
-    max_page_size = 1000000
-
     def get_paginated_response(self, data):
         result = OrderedDict()
         links = OrderedDict()
@@ -20,5 +17,17 @@ class HalPageNumberPagination(PageNumberPagination):
         result[LINKS_FIELD_NAME] = links
         result['count'] = self.page.paginator.count
         result['page_size'] = self.get_page_size(self.request)
-        result[EMBEDDED_FIELD_NAME] = data
+        result[EMBEDDED_FIELD_NAME] = {'items': data}
+        return Response(result)
+
+
+class HalCursorPagination(CursorPagination):
+    def get_paginated_response(self, data):
+        result = OrderedDict()
+        links = OrderedDict()
+        links[api_settings.URL_FIELD_NAME] = self.base_url
+        links['next'] = self.get_next_link()
+        links['previous'] = self.get_previous_link()
+        result[LINKS_FIELD_NAME] = links
+        result[EMBEDDED_FIELD_NAME] = {'items': data}
         return Response(result)

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from rest_framework.fields import empty
 from rest_framework.relations import HyperlinkedIdentityField, HyperlinkedRelatedField, ManyRelatedField, RelatedField
 from rest_framework.serializers import BaseSerializer, HyperlinkedModelSerializer
+from rest_framework.utils.field_mapping import get_nested_relation_kwargs
 
 from drf_hal_json import EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME
 
@@ -106,3 +107,18 @@ class HalModelSerializer(HyperlinkedModelSerializer):
     @staticmethod
     def _is_embedded_field(field):
         return isinstance(field, BaseSerializer)
+
+    def build_nested_field(self, field_name, relation_info, nested_depth):
+        """
+        Create nested fields for forward and reverse relationships.
+        """
+        class NestedSerializer(HalModelSerializer):
+            class Meta:
+                model = relation_info.related_model
+                depth = nested_depth - 1
+                fields = '__all__'
+
+        field_class = NestedSerializer
+        field_kwargs = get_nested_relation_kwargs(relation_info)
+
+        return field_class, field_kwargs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 Django==1.11.1
 djangorestframework==3.6.2
-drf-nested-fields==0.9.3

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,7 @@ setup(
     packages=find_packages(exclude=['tests*']),
     install_requires=[
         'django>=1.6',
-        'djangorestframework>=3.0.0',
-        'drf-nested-fields>=0.9.0'
+        'djangorestframework>=3.0.0'
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Fixes using custom `HyperlinkedRelatedField` options and serializers for related fields.

Also this now works more closely like `HyperlinkedModelSerializer` in that you have to define `url` in the fields as well. We should probably turn that into `self` somehow.